### PR TITLE
chore: enhance CI workflow by adding pnpm cache and updating corepack…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,10 +22,16 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version: 20
-          cache: pnpm
-          cache-dependency-path: pnpm-lock.yaml
 
-      - run: npm i -g --force corepack@latest && corepack enable
+      - run: npm i -g --force corepack@latest && corepack enable && corepack prepare pnpm@10 --activate
+
+      - name: Cache pnpm store
+        uses: actions/cache@v4
+        with:
+          path: ~/.pnpm-store
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
 
       - name: Install dependencies
         run: npx nypm@latest i
@@ -57,10 +63,17 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version: 20
-          cache: pnpm
-          cache-dependency-path: pnpm-lock.yaml
 
-      - run: npm i -g --force corepack@latest && corepack enable
+      - run: npm i -g --force corepack@latest && corepack enable && corepack prepare pnpm@10 --activate
+
+      - name: Cache pnpm store
+        uses: actions/cache@v4
+        with:
+          path: ~/.pnpm-store
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('pnpm-lock.yaml') }}-${{ matrix.nuxt }}-${{ matrix.zod }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-${{ hashFiles('pnpm-lock.yaml') }}-
+            ${{ runner.os }}-pnpm-store-
 
       - name: Install dependencies
         run: npx nypm@latest i


### PR DESCRIPTION
## Linked issue or discussion
<!-- Example: Resolves #123 -->

## Type of change
- [ ] Feature
- [x] Bug fix
- [ ] Documentation

## Summary

This pull request updates the CI workflow to improve how pnpm dependencies are cached and managed. The main changes involve switching from the built-in pnpm cache in `setup-node` to a more explicit caching strategy using the `actions/cache` action, and ensuring a specific pnpm version is activated.

Dependency management and caching improvements:

* Replaced `setup-node`'s built-in pnpm cache with a dedicated `actions/cache` step that caches the pnpm store at `~/.pnpm-store`, improving cache reliability and control. [[1]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL25-R34) [[2]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL60-R76)
* Enhanced the cache key to include the OS, the hash of `pnpm-lock.yaml`, and relevant matrix variables (such as `nuxt` and `zod`), making cache hits more accurate for different job configurations.
* Explicitly prepared and activated pnpm version 10 using `corepack prepare pnpm@10 --activate` to ensure consistent pnpm usage across CI runs. [[1]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL25-R34) [[2]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL60-R76)

## Validation
- [x] PR title follows Conventional Commits
- [ ] I ran `npm run lint` (or marked not applicable)
- [ ] I ran `npm run test` (or marked not applicable)
- [ ] I ran `npm run test:types` when TypeScript types or public API changed

## Docs
- [ ] I updated documentation/examples when needed
- [ ] No documentation update is needed
