### PR TITLE
Dev

### DIFF
--- a/.cursor/rules/80-testing-ci-release.mdc
+++ b/.cursor/rules/80-testing-ci-release.mdc
@@ -13,6 +13,7 @@ alwaysApply: false
 
 - Regressões **SHOULD** usar **Vitest** + **`@nuxt/test-utils/e2e`** com `setup({ rootDir })` apontando para fixture em [`test/fixtures/`](test/fixtures/) ([`test/basic.test.ts`](test/basic.test.ts)).
 - Fixtures **SHOULD** importar o módulo fonte como em [`test/fixtures/basic/nuxt.config.ts`](test/fixtures/basic/nuxt.config.ts) (`../../../src/module`) para testar o código atual, não só o pacote publicado.
+- Uma fixture complementar **MAY** importar [`dist/module.mjs`](dist/module.mjs) após `nuxt-module-build build` (ver [`test/dist-module.test.ts`](test/dist-module.test.ts) e [`test/fixtures/dist-module/`](test/fixtures/dist-module/)) para validar o artefato empacotado (resolução de runtime em `dist/`, exports npm).
 
 ## Playground
 

--- a/src/module.ts
+++ b/src/module.ts
@@ -24,6 +24,17 @@ function runtimeImportPath(absolutePath: string): string {
   return absolutePath.replace(/\\/g, '/')
 }
 
+/**
+ * From `src/module.ts` runtime lives as `.ts`; from `dist/module.mjs` the builder emits `.js` only.
+ */
+function resolveRuntimeEntry(zodRoot: string, ...pathSegments: string[]) {
+  const base = join(zodRoot, ...pathSegments)
+  const tsCandidate = `${base}.ts`
+  if (existsSync(tsCandidate)) return runtimeImportPath(tsCandidate)
+  const jsCandidate = `${base}.js`
+  return runtimeImportPath(jsCandidate)
+}
+
 export type {
   ZodErrorMessages,
 } from './runtime/v3/zod-errors'
@@ -132,12 +143,12 @@ export default defineNuxtModule<ModuleOptions>({
     }
     const zodRoot = resolve(`./runtime/${zodVersion}`)
     const zodSpecifier = zodVersion === 'v4' ? 'zod/v4' : 'zod/v3'
-    const useZodComposable = runtimeImportPath(join(zodRoot, 'composables/useZod.ts'))
-    const appPlugin = runtimeImportPath(join(zodRoot, 'plugin.ts'))
-    const serverUseZod = runtimeImportPath(join(zodRoot, 'server/utils/useZod.ts'))
-    const serverPlugin = runtimeImportPath(join(zodRoot, 'server/plugin.ts'))
-    const appPluginErrors = runtimeImportPath(join(zodRoot, 'plugin-errors.ts'))
-    const serverPluginErrors = runtimeImportPath(join(zodRoot, 'server/plugin-errors.ts'))
+    const useZodComposable = resolveRuntimeEntry(zodRoot, 'composables', 'useZod')
+    const appPlugin = resolveRuntimeEntry(zodRoot, 'plugin')
+    const serverUseZod = resolveRuntimeEntry(zodRoot, 'server/utils', 'useZod')
+    const serverPlugin = resolveRuntimeEntry(zodRoot, 'server', 'plugin')
+    const appPluginErrors = resolveRuntimeEntry(zodRoot, 'plugin-errors')
+    const serverPluginErrors = resolveRuntimeEntry(zodRoot, 'server', 'plugin-errors')
 
     type NuxtZodRuntimeConfig = {
       validation?: {

--- a/test/dist-module.test.ts
+++ b/test/dist-module.test.ts
@@ -1,0 +1,34 @@
+import { execFileSync } from 'node:child_process'
+import { existsSync } from 'node:fs'
+import { join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { describe, it, expect } from 'vitest'
+import { setup, $fetch } from '@nuxt/test-utils/e2e'
+
+const repoRoot = fileURLToPath(new URL('..', import.meta.url))
+
+function buildModulePackage() {
+  const cli = join(repoRoot, 'node_modules', '@nuxt', 'module-builder', 'dist', 'cli.mjs')
+  if (!existsSync(cli)) {
+    throw new Error(`nuxt-module-build CLI não encontrado em ${cli}`)
+  }
+  execFileSync(process.execPath, [cli, 'build'], { cwd: repoRoot, stdio: 'inherit' })
+}
+
+describe('nuxt-zod (dist entry)', async () => {
+  buildModulePackage()
+
+  await setup({
+    rootDir: fileURLToPath(new URL('./fixtures/dist-module', import.meta.url)),
+  })
+
+  it('carrega o módulo a partir de dist/module.mjs (app + plugins)', async () => {
+    const html = await $fetch('/')
+    expect(html).toContain('dist-module-app-ok')
+  })
+
+  it('carrega o módulo a partir de dist/module.mjs (Nitro + useZod)', async () => {
+    const data = await $fetch('/api/dist-module-smoke') as { ok?: boolean }
+    expect(data.ok).toBe(true)
+  })
+})

--- a/test/fixtures/dist-module/app.vue
+++ b/test/fixtures/dist-module/app.vue
@@ -1,0 +1,10 @@
+<template>
+  <div id="dist-module-app">
+    {{ marker }}
+  </div>
+</template>
+
+<script setup lang="ts">
+const z = useZod()
+const marker = z.string().safeParse('ok').success ? 'dist-module-app-ok' : 'dist-module-app-fail'
+</script>

--- a/test/fixtures/dist-module/nuxt.config.ts
+++ b/test/fixtures/dist-module/nuxt.config.ts
@@ -1,0 +1,9 @@
+import nuxtZod from '../../../dist/module.mjs'
+
+export default defineNuxtConfig({
+  modules: [nuxtZod],
+  nuxtZod: {
+    zodVersion: 'v4',
+    schemas: { enabled: false },
+  },
+})

--- a/test/fixtures/dist-module/package.json
+++ b/test/fixtures/dist-module/package.json
@@ -1,0 +1,5 @@
+{
+  "private": true,
+  "name": "dist-module",
+  "type": "module"
+}

--- a/test/fixtures/dist-module/server/api/dist-module-smoke.get.ts
+++ b/test/fixtures/dist-module/server/api/dist-module-smoke.get.ts
@@ -1,0 +1,4 @@
+export default defineEventHandler(() => {
+  const z = useZod()
+  return { ok: z.number().safeParse(1).success }
+})


### PR DESCRIPTION
## Type of change
- [ ] Feature
- [x] Bug fix
- [ ] Documentation

## Summary

Paths para os arquivos de runtime eram hardcoded com extensão `.ts` via `runtimeImportPath(join(zodRoot, 'plugin.ts'))`. Isso funcionava no source mas quebrava após o build, pois o `@nuxt/module-builder` emite os arquivos de runtime sem a extensão `.ts`.

Introduz `resolveRuntimeEntry()`: tenta `.ts` primeiro (source), cai no `.js` se não encontrado (dist). Todos os seis paths de runtime (`plugin`, `plugin-errors`, `composables/useZod`, `server/plugin`, `server/plugin-errors`, `server/utils/useZod`) foram migrados para usar a nova função.

Adiciona fixture `test/fixtures/dist-module` e testes e2e em `test/dist-module.test.ts` que compilam o módulo via `@nuxt/module-builder` e sobem uma aplicação Nuxt apontando para `dist/module.mjs`, cobrindo tanto o app client (`useZod()` em componente) quanto a server route (`useZod()` no Nitro).

## Validation
- [x] PR title follows Conventional Commits
- [x] I ran `npm run lint` (or marked not applicable)
- [x] I ran `npm run test` (or marked not applicable)
- [ ] I ran `npm run test:types` when TypeScript types or public API changed

## Docs
- [x] No documentation update is needed