### PR TITLE
feat: add locale support for nuxt-zod with new locales page

### DIFF
--- a/playground/nuxt.config.ts
+++ b/playground/nuxt.config.ts
@@ -4,6 +4,10 @@ export default defineNuxtConfig({
   compatibilityDate: 'latest',
   nuxtZod: {
     zodVersion: 'v4',
+    locale: {
+      default: 'pt',
+      locales: ['pt', 'es', 'fr'],
+    },
     client: true,
     server: true,
     schemas: {

--- a/playground/pages/locales.vue
+++ b/playground/pages/locales.vue
@@ -1,0 +1,202 @@
+<template>
+  <main class="page">
+    <header class="hero">
+      <p class="eyebrow">
+        nuxt-zod playground
+      </p>
+      <h1>Locale test</h1>
+      <p>
+        Default: <strong>{{ defaultLocale }}</strong> · bundled:
+        <code>{{ bundledLocales.join(', ') }}</code>
+      </p>
+      <NuxtLink
+        class="back"
+        to="/"
+      >
+        Back to home
+      </NuxtLink>
+    </header>
+
+    <section class="card">
+      <h2>Active locale</h2>
+      <div class="actions">
+        <button
+          v-for="code in bundledLocales"
+          :key="code"
+          type="button"
+          :class="{ active: activeLocale === code }"
+          @click="setLocale(code)"
+        >
+          {{ code }}
+        </button>
+      </div>
+      <p class="hint">
+        Validates <code>z.string().min(5)</code> with value <code>"a"</code>
+      </p>
+      <button
+        type="button"
+        class="primary"
+        @click="runValidation"
+      >
+        Run validation
+      </button>
+      <p
+        v-if="message"
+        class="error"
+      >
+        {{ message }}
+      </p>
+      <pre class="result">{{ result }}</pre>
+    </section>
+  </main>
+</template>
+
+<script setup lang="ts">
+const defaultLocale = 'pt'
+const bundledLocales = ['pt', 'es', 'fr'] as const
+
+type LocaleCode = (typeof bundledLocales)[number]
+
+const { $zod: z } = useNuxtApp()
+const activeLocale = ref<LocaleCode>(defaultLocale)
+const message = ref('')
+const result = ref('Click a locale, then run validation.')
+
+function localeFactory(code: LocaleCode) {
+  const factories = z.locales as Record<string, () => ReturnType<typeof z.locales.pt>>
+  const factory = factories[code]
+  if (!factory) {
+    throw new Error(`Locale "${code}" is not in z.locales (check nuxtZod.locale.locales)`)
+  }
+  return factory()
+}
+
+function setLocale(code: LocaleCode) {
+  activeLocale.value = code
+  z.config(localeFactory(code))
+  message.value = ''
+  result.value = `Active locale set to "${code}". Run validation to see error messages.`
+}
+
+function runValidation() {
+  z.config(localeFactory(activeLocale.value))
+  const parsed = z.string().min(5).safeParse('a')
+  if (!parsed.success) {
+    message.value = parsed.error.issues[0]?.message ?? 'Validation failed'
+    result.value = JSON.stringify(parsed.error.issues, null, 2)
+    return
+  }
+  message.value = ''
+  result.value = 'Unexpected: validation passed.'
+}
+
+onMounted(() => {
+  setLocale(defaultLocale)
+})
+</script>
+
+<style scoped>
+.page {
+  max-width: 36rem;
+  margin: 0 auto;
+  padding: 2rem 1.25rem 3rem;
+  font-family: system-ui, sans-serif;
+  color: #0f172a;
+}
+
+.hero h1 {
+  margin: 0.25rem 0 0.5rem;
+}
+
+.hero p {
+  margin: 0;
+  color: #334155;
+  line-height: 1.5;
+}
+
+.eyebrow {
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  font-size: 0.75rem;
+  color: #64748b;
+  margin: 0;
+}
+
+.back {
+  display: inline-block;
+  margin-top: 0.75rem;
+  color: #c2410c;
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.card {
+  border: 1px solid #cbd5e1;
+  border-radius: 14px;
+  background: #fff;
+  padding: 1.1rem;
+  margin-top: 1.25rem;
+}
+
+.card h2 {
+  margin: 0 0 0.75rem;
+  font-size: 1.1rem;
+}
+
+.hint {
+  margin: 0.75rem 0;
+  font-size: 0.88rem;
+  color: #475569;
+}
+
+.actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+button {
+  border: 0;
+  border-radius: 10px;
+  background: #e2e8f0;
+  color: #0f172a;
+  font-weight: 600;
+  padding: 0.5rem 0.75rem;
+  cursor: pointer;
+}
+
+button.active {
+  background: #fed7aa;
+  outline: 2px solid #ea580c;
+}
+
+button.primary {
+  background: linear-gradient(120deg, #ea580c, #f59e0b);
+  color: #fff;
+}
+
+.error {
+  margin: 0.75rem 0 0;
+  color: #dc2626;
+  font-size: 0.9rem;
+  font-weight: 600;
+}
+
+.result {
+  margin: 0.75rem 0 0;
+  border-radius: 10px;
+  background: #0f172a;
+  color: #e2e8f0;
+  font-size: 0.8rem;
+  min-height: 80px;
+  overflow: auto;
+  padding: 0.75rem;
+}
+
+code {
+  font-size: 0.9em;
+  background: #f1f5f9;
+  padding: 0.1rem 0.25rem;
+  border-radius: 4px;
+}
+</style>

--- a/src/build/zod-locale-stub.ts
+++ b/src/build/zod-locale-stub.ts
@@ -1,0 +1,96 @@
+export interface NuxtZodLocaleOptions {
+  /** Active locale applied via `z.config()` on the client. */
+  default: string
+  /** Locale files kept in the client bundle for `z.locales.*`. */
+  locales: string[]
+}
+
+export type NuxtZodLocaleOption = string | NuxtZodLocaleOptions
+
+export type ResolvedNuxtZodLocaleConfig = {
+  default: string
+  locales: string[]
+}
+
+export function resolveNuxtZodLocaleConfig(
+  option?: NuxtZodLocaleOption,
+): ResolvedNuxtZodLocaleConfig {
+  if (option === undefined) {
+    return { default: 'en', locales: [] }
+  }
+  if (typeof option === 'string') {
+    return { default: option, locales: [] }
+  }
+  return {
+    default: option.default,
+    locales: [...new Set(option.locales)],
+  }
+}
+
+export function createZodLocaleClientPluginSource(defaultLocale: string): string {
+  return `import { defineNuxtPlugin } from '#app'
+
+export default defineNuxtPlugin({
+  name: 'nuxt-zod-locale',
+  enforce: 'pre',
+  async setup() {
+    const { z } = await import('zod/v4')
+    const { default: locale } = await import('zod/v4/locales/${defaultLocale}.js')
+    z.config(locale())
+  },
+})
+`
+}
+
+const EMPTY_BARREL = 'export {}\n'
+const NOOP_LOCALE_ID = '\0nuxt-zod:noop-locale'
+const ZOD_LOCALES_INDEX = '/zod/v4/locales/index.js'
+
+function normalizePath(path: string): string {
+  return path.replace(/\\/g, '/')
+}
+
+function filterZodLocalesIndex(source: string, localeFiles: string[]): string {
+  if (localeFiles.length === 0) {
+    return EMPTY_BARREL
+  }
+  const allowed = new Set(localeFiles.map(file => `./${file}.js`))
+  const lines = source.split(/\r?\n/).filter((line) => {
+    const match = line.match(/from\s+['"](\.\/[^'"]+)['"]/)
+    return match !== null && allowed.has(match[1]!)
+  })
+  return lines.length > 0 ? `${lines.join('\n')}\n` : EMPTY_BARREL
+}
+
+/** Vite plugin: trims Zod's locale barrel and noops built-in `en` when another default is set. */
+export function createZodLocaleStubPlugin(
+  { default: defaultLocale, locales }: ResolvedNuxtZodLocaleConfig,
+  clientBuild = true,
+) {
+  const skipBuiltInEn = defaultLocale !== 'en'
+
+  return {
+    name: 'nuxt-zod:locale-stub',
+    enforce: 'pre' as const,
+    resolveId(source: string, importer: string | undefined) {
+      if (!clientBuild || !skipBuiltInEn) {
+        return
+      }
+      const normalized = normalizePath(source)
+      const fromExternal = importer !== undefined && normalizePath(importer).includes('/zod/v4/classic/external')
+      if (fromExternal && (normalized.endsWith('/locales/en.js') || normalized === 'zod/v4/locales/en.js')) {
+        return NOOP_LOCALE_ID
+      }
+    },
+    load(id: string) {
+      if (id === NOOP_LOCALE_ID) {
+        return 'export default function noopLocale() { return {} }\n'
+      }
+    },
+    transform(code: string, id: string) {
+      if (clientBuild && normalizePath(id).includes(ZOD_LOCALES_INDEX)) {
+        return filterZodLocalesIndex(code, locales)
+      }
+    },
+  }
+}

--- a/src/module.ts
+++ b/src/module.ts
@@ -1,6 +1,7 @@
 import {
   defineNuxtModule,
   addPlugin,
+  addPluginTemplate,
   addImports,
   addServerImports,
   addServerPlugin,
@@ -12,6 +13,13 @@ import {
 import { existsSync } from 'node:fs'
 import { join } from 'node:path'
 import { getNuxtZodTypeTemplateContents } from './build/nuxt-zod-type-template'
+import {
+  createZodLocaleClientPluginSource,
+  createZodLocaleStubPlugin,
+  resolveNuxtZodLocaleConfig,
+  type NuxtZodLocaleOption,
+  type NuxtZodLocaleOptions,
+} from './build/zod-locale-stub'
 import {
   discoverSchemaFiles,
   generateUseZodSchemasSource,
@@ -46,6 +54,10 @@ export type {
   InferValidated,
   NuxtZodRuntimeValidation,
 } from './runtime/v4/validation-types'
+export type {
+  NuxtZodLocaleOption,
+  NuxtZodLocaleOptions,
+} from './build/zod-locale-stub'
 
 export interface ModuleOptions {
   /**
@@ -105,6 +117,18 @@ export interface ModuleOptions {
    * @default 'v4' (auto, with warning)
    */
   zodVersion?: 'v3' | 'v4'
+  /**
+   * Zod v4 client locale for default error messages.
+   *
+   * - **String** — shorthand for `{ default: '<code>' }`.
+   * - **Object** — `default` is applied via `z.config()`; `locales` lists files kept
+   *   in the bundle for `z.locales.*` (exactly as provided, without merging `default`).
+   *
+   * Only applies when `zodVersion === 'v4'` and `client !== false`.
+   *
+   * @default 'en'
+   */
+  locale?: NuxtZodLocaleOption
 }
 
 export default defineNuxtModule<ModuleOptions>({
@@ -226,8 +250,30 @@ export default defineNuxtModule<ModuleOptions>({
 
     // ─── App-side (client + SSR) ──────────────────────────────────────────
     if (options.client !== false) {
-      // Provides $zod on the NuxtApp instance
       addPlugin(appPlugin)
+
+      if (zodVersion === 'v4') {
+        const localeConfig = resolveNuxtZodLocaleConfig(options.locale)
+
+        nuxt.hook('vite:extendConfig', (viteConfig, { isClient }) => {
+          const plugin = createZodLocaleStubPlugin(localeConfig, isClient)
+          if (viteConfig.plugins) {
+            viteConfig.plugins.push(plugin)
+          }
+          else {
+            Object.assign(viteConfig, { plugins: [plugin] })
+          }
+        })
+
+        if (localeConfig.default !== 'en') {
+          addPluginTemplate({
+            filename: 'nuxt-zod/locale.client.mjs',
+            mode: 'client',
+            getContents: () => createZodLocaleClientPluginSource(localeConfig.default),
+          })
+        }
+      }
+
       if (hasGlobalZodErrorMessages) {
         // Register error-map bootstrap only when app.config declares zod.errors.
         addPlugin(appPluginErrors)

--- a/src/module.ts
+++ b/src/module.ts
@@ -18,7 +18,6 @@ import {
   createZodLocaleStubPlugin,
   resolveNuxtZodLocaleConfig,
   type NuxtZodLocaleOption,
-  type NuxtZodLocaleOptions,
 } from './build/zod-locale-stub'
 import {
   discoverSchemaFiles,


### PR DESCRIPTION
## Linked issue
Resolves #33

## Summary
Adds Zod v4 client locale support so apps can set default validation messages (e.g. `pt`) and keep only the needed locale files in the client bundle, instead of relying on Zod’s built-in `en` and pulling the full locales barrel.

## Changes
- Add `nuxtZod.locale` module option (`string` or `{ default, locales }`) and resolve it in `zod-locale-stub.ts`
- Register a Vite stub that trims `zod/v4/locales` to the configured list and noops built-in `en` when another default is set
- Inject a client plugin that applies `z.config(locale())` for the configured default (when not `en`)
- Demo in playground: `locale` in `nuxt.config.ts` and a `locales.vue` page to switch/test validation messages

## Validation
- [x] PR title follows Conventional Commits
- [x] I ran `npm run lint`
- [x] I ran `npm run test`
- [x] I ran `npm run test:types` (if TypeScript types or module public API changed)

## Docs
- [x] I updated documentation/examples when behavior or API changed
- [ ] No documentation update is needed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable Zod validation locales for Nuxt applications.
  * Supports Portuguese, Spanish, French, and other locale configurations, including a default locale.
  * Added a locale testing page with locale selection and validation feedback.
  * Client bundles now include only the configured validation locales, helping reduce unnecessary locale data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->